### PR TITLE
Added measurements, tattoos, piercings, and career...

### DIFF
--- a/plugins/freeones/README.md
+++ b/plugins/freeones/README.md
@@ -1,15 +1,15 @@
-## freeones 0.5.0
+## freeones 0.5.1
 
 by boi123212321,john4valor
 
 Scrape data from freeones.xxx. You do not need to have all possible Custom Fields. Custom Fields can only be named as follows (not case sensitive): Started, Ended, Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac, Bra, Chest, Cupsize, Waist, Hips, Measurements, Tattoos, Piercings
 ### Arguments
 
-| Name        | Type          | Required | Description                                                                                                                                                                                                                              |
-| ----------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                                                                                           |
-| blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;started&#x27;, &#x27;ended&#x27;, &#x27;description&#x27;, &#x27;tattoos&#x27;, &#x27;piercings&#x27;, &#x27;measurements&#x27;, &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
-| useImperial | String        | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                                                                                              |
+| Name        | Type          | Required | Description                                                                                                                                                                                                                    |
+| ----------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                                                                                 |
+| blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;career&#x27;, &#x27;description&#x27;, &#x27;tattoos&#x27;, &#x27;piercings&#x27;, &#x27;measurements&#x27;, &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
+| useImperial | String        | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                                                                                    |
 ### Example installation
 
 ```json

--- a/plugins/freeones/README.md
+++ b/plugins/freeones/README.md
@@ -1,15 +1,15 @@
-## freeones 0.4.0
+## freeones 0.5.0
 
 by boi123212321,john4valor
 
-Scrape data from freeones.xxx. Custom fields can only be named as follows (not case sensitive): Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac
+Scrape data from freeones.xxx. You do not need to have all possible Custom Fields. Custom Fields can only be named as follows (not case sensitive): Started, Ended, Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac, Bra, Chest, Cupsize, Waist, Hips, Measurements, Tattoos, Piercings
 ### Arguments
 
-| Name        | Type          | Required | Description                                                                                                                                                   |
-| ----------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                |
-| blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
-| useImperial | String        | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
+| Name        | Type          | Required | Description                                                                                                                                                                                                                              |
+| ----------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                                                                                           |
+| blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;started&#x27;, &#x27;ended&#x27;, &#x27;description&#x27;, &#x27;tattoos&#x27;, &#x27;piercings&#x27;, &#x27;measurements&#x27;, &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
+| useImperial | String        | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                                                                                              |
 ### Example installation
 
 ```json

--- a/plugins/freeones/info.json
+++ b/plugins/freeones/info.json
@@ -1,6 +1,6 @@
 {
   "name": "freeones",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "authors": ["boi123212321","john4valor"],
   "description": "Scrape data from freeones.xxx. You do not need to have all possible Custom Fields. Custom Fields can only be named as follows (not case sensitive): Started, Ended, Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac, Bra, Chest, Cupsize, Waist, Hips, Measurements, Tattoos, Piercings",
   "arguments": [
@@ -16,7 +16,7 @@
       "type": "Array<String>",
       "required": false,
       "default": [],
-      "description": "Array of data fields to omit (possible values: 'started', 'ended', 'description', 'tattoos', 'piercings', 'measurements', 'zodiac', 'aliases', 'height', 'weight', 'avatar', 'bornOn', 'labels', 'hair color', 'eye color', 'ethnicity')"
+      "description": "Array of data fields to omit (possible values: 'career', 'description', 'tattoos', 'piercings', 'measurements', 'zodiac', 'aliases', 'height', 'weight', 'avatar', 'bornOn', 'labels', 'hair color', 'eye color', 'ethnicity')"
     },
 	{
       "name": "useImperial",

--- a/plugins/freeones/info.json
+++ b/plugins/freeones/info.json
@@ -1,8 +1,8 @@
 {
   "name": "freeones",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "authors": ["boi123212321","john4valor"],
-  "description": "Scrape data from freeones.xxx. Custom fields can only be named as follows (not case sensitive): Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac",
+  "description": "Scrape data from freeones.xxx. You do not need to have all possible Custom Fields. Custom Fields can only be named as follows (not case sensitive): Started, Ended, Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac, Bra, Chest, Cupsize, Waist, Hips, Measurements, Tattoos, Piercings",
   "arguments": [
     {
       "name": "dry",
@@ -16,7 +16,7 @@
       "type": "Array<String>",
       "required": false,
       "default": [],
-      "description": "Array of data fields to omit (possible values: 'zodiac', 'aliases', 'height', 'weight', 'avatar', 'bornOn', 'labels', 'hair color', 'eye color', 'ethnicity')"
+      "description": "Array of data fields to omit (possible values: 'started', 'ended', 'description', 'tattoos', 'piercings', 'measurements', 'zodiac', 'aliases', 'height', 'weight', 'avatar', 'bornOn', 'labels', 'hair color', 'eye color', 'ethnicity')"
     },
 	{
       "name": "useImperial",

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -27,8 +27,8 @@ module.exports = async ({
   }
 
   //Check imperial unit preference
-  const imp_pref = args.useImperial;
-  if (!imp_pref) {
+  const useImperial = args.useImperial;
+  if (!useImperial) {
     $log("Imperial preference not set. Using metric values...");
   } else {
     $log("Imperial preference indicated. Using imperial values...");
@@ -50,16 +50,16 @@ module.exports = async ({
     if (isBlacklisted("nationality")) return {};
     $log("Getting nationality...");
 
-    const nat_sel = $(
+    const selector = $(
       '[data-test="section-personal-information"] a[href*="countryCode%5D"]'
     );
 
-    if (!nat_sel.length) {
+    if (!selector.length) {
       $log("Nationality not found");
       return {};
     }
 
-    const nationality = $(nat_sel).attr("href").split("=").slice(-1)[0];
+    const nationality = $(selector).attr("href").split("=").slice(-1)[0];
     if (!nationality) {
       return {};
     }
@@ -72,75 +72,75 @@ module.exports = async ({
     if (isBlacklisted("height")) return {};
     $log("Getting height...");
 
-    const htsel = $('[data-test="link_height"] .text-underline-always');
-    if (!htsel) return {};
+    const selector = $('[data-test="link_height"] .text-underline-always');
+    if (!selector) return {};
 
-    const rawht = $(htsel).text();
-    const ht_cm = rawht.match(/\d+cm/)[0];
-    if (!ht_cm) return {};
-    let hgt = parseInt(ht_cm.replace("cm", ""));
-    if (!imp_pref) return { height: hgt };
-    hgt *= 0.033;
-    hgt = Math.round((hgt + Number.EPSILON) * 100) / 100;
-    return { height: hgt };
+    const rawHeight = $(selector).text();
+    const cm = rawHeight.match(/\d+cm/)[0];
+    if (!cm) return {};
+    let height = parseInt(cm.replace("cm", ""));
+    if (!useImperial) return { height };
+    // Convert to imperial
+    height *= 0.033;
+    height = Math.round((height + Number.EPSILON) * 100) / 100;
+    return { height: height };
   }
 
   function getWeight() {
     if (isBlacklisted("weight")) return {};
     $log("Getting weight...");
 
-    const wtsel = $('[data-test="link_weight"] .text-underline-always');
-    if (!wtsel) return {};
+    const selector = $('[data-test="link_weight"] .text-underline-always');
+    if (!selector) return {};
 
-    const rawwt = $(wtsel).text();
-    const wt_kg = rawwt.match(/\d+kg/)[0];
-    if (!wt_kg) return {};
-    let wgt = parseInt(wt_kg.replace("kg", ""));
-    if (!imp_pref) return { weight: wgt };
-    wgt *= 2.2;
-    wgt = Math.round((wgt + Number.EPSILON) * 100) / 100;
-    return { weight: wgt };
+    const rawWeight = $(selector).text();
+    const kg = rawWeight.match(/\d+kg/)[0];
+    if (!kg) return {};
+    let weight = parseInt(kg.replace("kg", ""));
+    if (!useImperial) return { weight };
+    // Convert to imperial
+    weight *= 2.2;
+    weight = Math.round((weight + Number.EPSILON) * 100) / 100;
+    return { weight: weight };
   }
 
   function getZodiac() {
     if (isBlacklisted("zodiac")) return {};
     $log("Getting zodiac sign...");
 
-    const zod_sel = $('[data-test="link_zodiac"] .text-underline-always');
-    if (!zod_sel) return {};
-    const rawzod = $(zod_sel).text();
-    const zod_name = rawzod.split(" (")[0];
-
-    return { zodiac: zod_name };
+    const selector = $('[data-test="link_zodiac"] .text-underline-always');
+    if (!selector) return {};
+    const zodiacText = $(selector).text();
+    const zodiac = zodiacText.split(" (")[0];
+    return { zodiac };
   }
 
   function getBirthplace() {
     if (isBlacklisted("birthplace")) return {};
     $log("Getting birthplace...");
 
-    const bcity_sel = $(
+    const selector = $(
       '[data-test="section-personal-information"] a[href*="placeOfBirth"]'
     );
-    const bcity_name = bcity_sel.length
-      ? $(bcity_sel).attr("href").split("=").slice(-1)[0]
+    const cityName = selector.length
+      ? $(selector).attr("href").split("=").slice(-1)[0]
       : null;
-    let bplace = "";
-    if (!bcity_name) {
+
+    if (!cityName) {
       $log("No birthplace found");
       return {};
     } else {
-      const bstate_sel = $(
+      const stateSelector = $(
         '[data-test="section-personal-information"] a[href*="province"]'
       );
-      const bstate_name = bstate_sel.length
-        ? $(bstate_sel).attr("href").split("=").slice(-1)[0]
+      const stateName = stateSelector.length
+        ? $(stateSelector).attr("href").split("=").slice(-1)[0]
         : null;
-      if (!bstate_name) {
+      if (!stateName) {
         $log("No birth province found, just city!");
-        bplace = bcity_name;
-        return { birthplace: bplace };
+        return { birthplace: cityName };
       } else {
-        bplace = bcity_name + ", " + bstate_name.split("-")[0].trim();
+        let bplace = cityName + ", " + stateName.split("-")[0].trim();
         return { birthplace: bplace };
       }
     }

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -2,6 +2,16 @@ function lowercase(str) {
   return str.toLowerCase();
 }
 
+function cmToFt(cm) {
+  cm *= 0.033;
+  return Math.round((cm + Number.EPSILON) * 100) / 100;
+}
+
+function kgToLbs(kg) {
+  kg *= 2.2;
+  return Math.round((kg + Number.EPSILON) * 100) / 100;
+}
+
 module.exports = async ({
   $createImage,
   args,
@@ -80,10 +90,9 @@ module.exports = async ({
     if (!cm) return {};
     let height = parseInt(cm.replace("cm", ""));
     if (!useImperial) return { height };
+
     // Convert to imperial
-    height *= 0.033;
-    height = Math.round((height + Number.EPSILON) * 100) / 100;
-    return { height: height };
+    return { height: cmToFt(height) };
   }
 
   function getWeight() {
@@ -98,10 +107,9 @@ module.exports = async ({
     if (!kg) return {};
     let weight = parseInt(kg.replace("kg", ""));
     if (!useImperial) return { weight };
+
     // Convert to imperial
-    weight *= 2.2;
-    weight = Math.round((weight + Number.EPSILON) * 100) / 100;
-    return { weight: weight };
+    return { weight: kgToLbs(weight) };
   }
 
   function getZodiac() {

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -205,15 +205,34 @@ module.exports = async ({
     $log("Getting measurements...");
 
     const braSelector = $('[data-test="p-measurements"] a[href*="%5Bbra%5D"]');
-	const braSize = braSelector.attr("href").split("=").slice(-1)[0];
-	const chestSize = braSize.substr(0,2);
-	const cupSize = braSize.substr(2,1);
+	let braSize = "";
+	let chestSize = "";
+	let cupSize = "";
+	if (!braSelector) {
+		braSize = "";
+		chestSize = "";
+		cupSize = "";
+	} else {
+		braSize = braSelector.length ? braSelector.attr("href").split("=").slice(-1)[0] : null;
+		chestSize = braSize.substr(0,2);
+		cupSize = braSize.substr(2,1);
+	}
 	
 	const waistSelector = $('[data-test="p-measurements"] a[href*="%5Bwaist%5D"]');
-	const waistSize = waistSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0];
-	
+	let waistSize = "";
+	if (!waistSelector) {
+		waistSize = "";
+	} else {
+		waistSize = waistSelector.length ? waistSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0] : null;
+	}
+		
 	const hipSelector = $('[data-test="p-measurements"] a[href*="%5Bhip%5D"]');
-	const hipSize = hipSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0];
+	let hipSize = "";
+	if (!hipSelector) {
+		hipSize = "";
+	} else {
+		hipSize = hipSelector.length ? hipSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0] : null;
+	}
 	
 	const separator = "-";
 	

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -205,47 +205,70 @@ module.exports = async ({
     $log("Getting measurements...");
 
     const braSelector = $('[data-test="p-measurements"] a[href*="%5Bbra%5D"]');
-	let braSize = "";
-	let chestSize = "";
-	let cupSize = "";
-	if (!braSelector) {
-		braSize = "";
-		chestSize = "";
-		cupSize = "";
-	} else {
-		braSize = braSelector.length ? braSelector.attr("href").split("=").slice(-1)[0] : null;
-		chestSize = braSize.substr(0,2);
-		cupSize = braSize.substr(2,1);
-	}
-	
-	const waistSelector = $('[data-test="p-measurements"] a[href*="%5Bwaist%5D"]');
-	let waistSize = "";
-	if (!waistSelector) {
-		waistSize = "";
-	} else {
-		waistSize = waistSelector.length ? waistSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0] : null;
-	}
-		
-	const hipSelector = $('[data-test="p-measurements"] a[href*="%5Bhip%5D"]');
-	let hipSize = "";
-	if (!hipSelector) {
-		hipSize = "";
-	} else {
-		hipSize = hipSelector.length ? hipSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0] : null;
-	}
-	
-	const separator = "-";
-	
-	const fullMeasurements = braSize.concat(separator,waistSize,separator,hipSize);
-	
+    let braSize = "";
+    let chestSize = "";
+    let cupSize = "";
+    if (!braSelector) {
+      braSize = "";
+      chestSize = "";
+      cupSize = "";
+    } else {
+      braSize = braSelector.length
+        ? braSelector.attr("href").split("=").slice(-1)[0]
+        : null;
+      chestSize = braSize.substr(0, 2);
+      cupSize = braSize.substr(2, 1);
+    }
+
+    const waistSelector = $(
+      '[data-test="p-measurements"] a[href*="%5Bwaist%5D"]'
+    );
+    let waistSize = "";
+    if (!waistSelector) {
+      waistSize = "";
+    } else {
+      waistSize = waistSelector.length
+        ? waistSelector
+            .attr("href")
+            .split("=")
+            .slice(-1)[0]
+            .split(",")
+            .slice(-1)[0]
+        : null;
+    }
+
+    const hipSelector = $('[data-test="p-measurements"] a[href*="%5Bhip%5D"]');
+    let hipSize = "";
+    if (!hipSelector) {
+      hipSize = "";
+    } else {
+      hipSize = hipSelector.length
+        ? hipSelector
+            .attr("href")
+            .split("=")
+            .slice(-1)[0]
+            .split(",")
+            .slice(-1)[0]
+        : null;
+    }
+
+    const separator = "-";
+
+    const fullMeasurements = braSize.concat(
+      separator,
+      waistSize,
+      separator,
+      hipSize
+    );
+
     return {
-		bra: braSize,
-		chest: chestSize,
-		cupsize: cupSize,
-		waist: waistSize,
-		hips: hipSize,
-		measurements: fullMeasurements,
-	}
+      bra: braSize,
+      chest: chestSize,
+      cupsize: cupSize,
+      waist: waistSize,
+      hips: hipSize,
+      measurements: fullMeasurements,
+    };
   }
 
   function getAlias() {
@@ -263,27 +286,27 @@ module.exports = async ({
 
     return { aliases: alias_fin };
   }
-  
+
   function getCareer() {
     if (isBlacklisted("career")) return {};
     $log("Getting career info...");
 
     const careerSelector = $(".timeline-horizontal p.m-0");
-	if (!careerSelector) return {};
-	
-	let careerStart = $(careerSelector[0]).text();
-	if (careerStart === "Begin") {
-		careerStart = "";
-	}
-	let careerEnd = $(careerSelector[1]).text();
-	if (careerEnd === "Now") {
-		careerEnd = "";
-	}
-	
-	return {
-		started: careerStart,
-		ended: careerEnd,
-	}
+    if (!careerSelector) return {};
+
+    let careerStart = $(careerSelector[0]).text();
+    if (careerStart === "Begin") {
+      careerStart = "";
+    }
+    let careerEnd = $(careerSelector[1]).text();
+    if (careerEnd === "Now") {
+      careerEnd = "";
+    }
+
+    return {
+      started: careerStart,
+      ended: careerEnd,
+    };
   }
 
   const custom = {
@@ -299,30 +322,21 @@ module.exports = async ({
       "ethnicity",
       '[data-test="link_ethnicity"] .text-underline-always'
     ),
-	...scrapeText(
-      "tattoos",
-      '[data-test="p_has_tattoos"]'
-    ),
-	...scrapeText(
-      "piercings",
-      '[data-test="p_has_piercings"]'
-    ),
+    ...scrapeText("tattoos", '[data-test="p_has_tattoos"]'),
+    ...scrapeText("piercings", '[data-test="p_has_piercings"]'),
     ...getHeight(),
     ...getWeight(),
     ...getBirthplace(),
     ...getZodiac(),
-	...getMeasurements(),
-	...getCareer(),
+    ...getMeasurements(),
+    ...getCareer(),
   };
 
   const data = {
     ...getNationality(),
     ...getAge(),
     ...getAlias(),
-	...scrapeText(
-      "description",
-      '[data-test="p_additional_information"]'
-    ),
+    ...scrapeText("description", '[data-test="p_additional_information"]'),
     ...(await getAvatar()),
     custom,
   };

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -125,37 +125,6 @@ module.exports = async ({
     const zodiac = zodiacText.split(" (")[0];
     return { zodiac };
   }
-
-  function getBirthplace() {
-    if (isBlacklisted("birthplace")) return {};
-    $log("Getting birthplace...");
-
-    const selector = $(
-      '[data-test="section-personal-information"] a[href*="placeOfBirth"]'
-    );
-    const cityName = selector.length
-      ? $(selector).attr("href").split("=").slice(-1)[0]
-      : null;
-
-    if (!cityName) {
-      $log("No birthplace found");
-      return {};
-    } else {
-      const stateSelector = $(
-        '[data-test="section-personal-information"] a[href*="province"]'
-      );
-      const stateName = stateSelector.length
-        ? $(stateSelector).attr("href").split("=").slice(-1)[0]
-        : null;
-      if (!stateName) {
-        $log("No birth province found, just city!");
-        return { birthplace: cityName };
-      } else {
-        let bplace = cityName + ", " + stateName.split("-")[0].trim();
-        return { birthplace: bplace };
-      }
-    }
-  }
   
   function getBirthplace() {
     if (isBlacklisted("birthplace")) return {};

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -200,6 +200,35 @@ module.exports = async ({
     }
   }
 
+  function getMeasurements() {
+    if (isBlacklisted("measurements")) return {};
+    $log("Getting measurements...");
+
+    const braSelector = $('[data-test="p-measurements"] a[href*="%5Bbra%5D"]');
+	const braSize = braSelector.attr("href").split("=").slice(-1)[0];
+	const chestSize = braSize.substr(0,2);
+	const cupSize = braSize.substr(2,1);
+	
+	const waistSelector = $('[data-test="p-measurements"] a[href*="%5Bwaist%5D"]');
+	const waistSize = waistSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0];
+	
+	const hipSelector = $('[data-test="p-measurements"] a[href*="%5Bhip%5D"]');
+	const hipSize = hipSelector.attr("href").split("=").slice(-1)[0].split(",").slice(-1)[0];
+	
+	const separator = "-";
+	
+	const fullMeasurements = braSize.concat(separator,waistSize,separator,hipSize);
+	
+    return {
+		bra: braSize,
+		chest: chestSize,
+		cupsize: cupSize,
+		waist: waistSize,
+		hips: hipSize,
+		measurements: fullMeasurements,
+	}
+  }
+
   function getAlias() {
     if (isBlacklisted("aliases")) return {};
     $log("Getting aliases...");
@@ -215,6 +244,28 @@ module.exports = async ({
 
     return { aliases: alias_fin };
   }
+  
+  function getCareer() {
+    if (isBlacklisted("career")) return {};
+    $log("Getting career info...");
+
+    const careerSelector = $(".timeline-horizontal p.m-0");
+	if (!careerSelector) return {};
+	
+	let careerStart = $(careerSelector[0]).text();
+	if (careerStart === "Begin") {
+		careerStart = "";
+	}
+	let careerEnd = $(careerSelector[1]).text();
+	if (careerEnd === "Now") {
+		careerEnd = "";
+	}
+	
+	return {
+		started: careerStart,
+		ended: careerEnd,
+	}
+  }
 
   const custom = {
     ...scrapeText(
@@ -229,16 +280,30 @@ module.exports = async ({
       "ethnicity",
       '[data-test="link_ethnicity"] .text-underline-always'
     ),
+	...scrapeText(
+      "tattoos",
+      '[data-test="p_has_tattoos"]'
+    ),
+	...scrapeText(
+      "piercings",
+      '[data-test="p_has_piercings"]'
+    ),
     ...getHeight(),
     ...getWeight(),
     ...getBirthplace(),
     ...getZodiac(),
+	...getMeasurements(),
+	...getCareer(),
   };
 
   const data = {
     ...getNationality(),
     ...getAge(),
     ...getAlias(),
+	...scrapeText(
+      "description",
+      '[data-test="p_additional_information"]'
+    ),
     ...(await getAvatar()),
     custom,
   };

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -156,6 +156,36 @@ module.exports = async ({
       }
     }
   }
+  
+  function getBirthplace() {
+    if (isBlacklisted("birthplace")) return {};
+    $log("Getting birthplace...");
+
+    const citySelector = $('[data-test="section-personal-information"] a[href*="placeOfBirth"]');
+	let cityName = "";
+	if (citySelector) {
+		cityName = citySelector.length ? $(citySelector).attr("href").split("=").slice(-1)[0] : null;
+	}
+	
+	const stateSelector = $('[data-test="section-personal-information"] a[href*="province"]');
+	
+	let stateName = "";
+	if (stateSelector) {
+		stateName = stateSelector.length ? $(stateSelector).attr("href").split("=").slice(-1)[0] : null;
+	}
+	
+	if (cityName && stateName) {
+		return { birthplace: [cityName, stateName].join(", ") };
+	}
+	
+	if (cityName) {
+		return { birthplace: cityName };
+	}
+	
+	if (stateName) {
+		return { birthplace: stateName };
+	}
+  }
 
   function scrapeText(prop, selector) {
     if (isBlacklisted(prop)) return {};

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -2,13 +2,16 @@ function lowercase(str) {
   return str.toLowerCase();
 }
 
+// NIST Metric to Imperial conversion chart:
+// https://www.nist.gov/pml/weights-and-measures/approximate-conversions-metric-us-customary-measures
+
 function cmToFt(cm) {
-  cm *= 0.033;
+  cm *= 0.0328;
   return Math.round((cm + Number.EPSILON) * 100) / 100;
 }
 
 function kgToLbs(kg) {
-  kg *= 2.2;
+  kg *= 2.20;
   return Math.round((kg + Number.EPSILON) * 100) / 100;
 }
 
@@ -208,40 +211,32 @@ module.exports = async ({
     let braSize = "";
     let chestSize = "";
     let cupSize = "";
-    if (!braSelector) {
-      braSize = "";
-      chestSize = "";
-      cupSize = "";
-    } else {
+    if (braSelector) {
       braSize = braSelector.length
         ? braSelector.attr("href").split("=").slice(-1)[0]
         : null;
+	}
+	if (braSize) {
       chestSize = braSize.substr(0, 2);
       cupSize = braSize.substr(2, 1);
     }
 
-    const waistSelector = $(
-      '[data-test="p-measurements"] a[href*="%5Bwaist%5D"]'
-    );
+    const waistSelector = $('[data-test="p-measurements"] a[href*="%5Bwaist%5D"]');
     let waistSize = "";
-    if (!waistSelector) {
-      waistSize = "";
-    } else {
+    if (waistSelector) {
       waistSize = waistSelector.length
-        ? waistSelector
-            .attr("href")
-            .split("=")
-            .slice(-1)[0]
-            .split(",")
-            .slice(-1)[0]
-        : null;
+		? waistSelector
+			.attr("href")
+			.split("=")
+			.slice(-1)[0]
+			.split(",")
+			.slice(-1)[0]
+		: null;
     }
 
     const hipSelector = $('[data-test="p-measurements"] a[href*="%5Bhip%5D"]');
     let hipSize = "";
-    if (!hipSelector) {
-      hipSize = "";
-    } else {
+    if (hipSelector) {
       hipSize = hipSelector.length
         ? hipSelector
             .attr("href")
@@ -252,14 +247,7 @@ module.exports = async ({
         : null;
     }
 
-    const separator = "-";
-
-    const fullMeasurements = braSize.concat(
-      separator,
-      waistSize,
-      separator,
-      hipSize
-    );
+    const fullMeasurements = [braSize, waistSize, hipSize].join("-");
 
     return {
       bra: braSize,


### PR DESCRIPTION
Basically all metadata of-interest that FreeOnes has is pulled now. Only thing not pulled is shoe size.

If available, "Additional Information" section is pulled as a description.

Users can either pull the full measurement string (e.g., 32C-28-35), or each individual measurement as a separate string.

Apologies for all the unit test revisions needed.