### PR TITLE
fix(types): remove labels from movie event

### DIFF
--- a/plugins/label_filter/README.md
+++ b/plugins/label_filter/README.md
@@ -40,7 +40,10 @@ Filter labels returned by other plugins
       "sceneCustom": [
         "label_filter"
       ],
-      "movieCreated": [
+      "studioCreated": [
+        "label_filter"
+      ],
+      "studioCustom": [
         "label_filter"
       ]
     }
@@ -68,7 +71,9 @@ plugins:
       - label_filter
     sceneCustom:
       - label_filter
-    movieCreated:
+    studioCreated:
+      - label_filter
+    studioCustom:
       - label_filter
 
 ---

--- a/plugins/label_filter/info.json
+++ b/plugins/label_filter/info.json
@@ -8,7 +8,8 @@
     "actorCustom",
     "sceneCreated",
     "sceneCustom",
-    "movieCreated"
+    "studioCreated",
+    "studioCustom"
   ],
   "arguments": [
     {

--- a/plugins/label_filter/main.ts
+++ b/plugins/label_filter/main.ts
@@ -1,6 +1,6 @@
 import { ActorContext } from '../../types/actor';
 import { SceneContext } from '../../types/scene';
-import { StudioContext } from './../../types/studio';
+import { StudioContext } from '../../types/studio';
 
 interface MyContext {
   args: {

--- a/plugins/label_filter/main.ts
+++ b/plugins/label_filter/main.ts
@@ -1,6 +1,6 @@
-import { ActorContext } from "../../types/actor";
-import { MovieContext } from "../../types/movie";
-import { SceneContext } from "../../types/scene";
+import { ActorContext } from '../../types/actor';
+import { SceneContext } from '../../types/scene';
+import { StudioContext } from './../../types/studio';
 
 interface MyContext {
   args: {
@@ -11,7 +11,7 @@ interface MyContext {
 
 const lower = (s: string): string => s.toLowerCase();
 
-module.exports = ({ args, data }: (ActorContext | SceneContext | MovieContext) & MyContext) => {
+module.exports = ({ args, data }: (ActorContext | SceneContext | StudioContext) & MyContext) => {
   const whitelist = (args.whitelist || []).map(lower);
   const blacklist = (args.blacklist || []).map(lower);
 

--- a/types/movie.ts
+++ b/types/movie.ts
@@ -27,7 +27,6 @@ export interface FullMovieOutput extends CustomFieldsOutput {
   frontCover: string;
   backCover: string;
   spineCover: string;
-  labels: string[]; // TODO: implement in server
   studio: string;
 }
 

--- a/types/plugin.ts
+++ b/types/plugin.ts
@@ -37,7 +37,7 @@ export interface Context<Data = unknown> {
   // Plugin
   event: string;
   args?: unknown;
-  data: Data;
+  data: Partial<Data>;
 }
 
 export interface CustomFieldsOutput {


### PR DESCRIPTION
- `labels` should not be output for a movie event
- update 'label_filter` types in accordance, add 'studio' to readme