### PR TITLE
Fix traxxx & freeones

### DIFF
--- a/plugins/freeones/main.ts
+++ b/plugins/freeones/main.ts
@@ -238,7 +238,7 @@ module.exports = async (ctx: MyContext): Promise<ActorOutput> => {
     if (isBlacklisted("avatar")) return {};
     $log("Getting avatar...");
 
-    const imgEl = $(".profile-header .img-fluid");
+    const imgEl = $(`.dashboard-header img.img-fluid`);
     if (!imgEl) return {};
 
     const url = $(imgEl).attr("src");

--- a/plugins/traxxx/README.md
+++ b/plugins/traxxx/README.md
@@ -19,7 +19,7 @@ This plugin retrieves data from Traxxx.
     * `aliases` : aliases of the studio
     * `parent`: the parent channel/network
     * `custom` : custom fields:
-        * `Traxxx Slug` : the slug identifier (for use by plugins)
+        * `Traxxx Slug` : the matched id (for use by plugins)
         * `Traxxx Type` : the type of channel/network (for use by plugins)
         * `Homepage` : the Homepage of the studio
 

--- a/plugins/traxxx/README.md
+++ b/plugins/traxxx/README.md
@@ -19,7 +19,7 @@ This plugin retrieves data from Traxxx.
     * `aliases` : aliases of the studio
     * `parent`: the parent channel/network
     * `custom` : custom fields:
-        * `Traxxx Slug` : the matched id (for use by plugins)
+        * `Traxxx Slug` : the slug identifier (for use by plugins)
         * `Traxxx Type` : the type of channel/network (for use by plugins)
         * `Homepage` : the Homepage of the studio
 

--- a/plugins/traxxx/README.md
+++ b/plugins/traxxx/README.md
@@ -19,7 +19,7 @@ This plugin retrieves data from Traxxx.
     * `aliases` : aliases of the studio
     * `parent`: the parent channel/network
     * `custom` : custom fields:
-        * `Traxxx Id` : the matched id (for use by plugins)
+        * `Traxxx Slug` : the slug identifier (for use by plugins)
         * `Traxxx Type` : the type of channel/network (for use by plugins)
         * `Homepage` : the Homepage of the studio
 

--- a/plugins/traxxx/docs.md
+++ b/plugins/traxxx/docs.md
@@ -11,7 +11,7 @@ This plugin retrieves data from Traxxx.
     * `aliases` : aliases of the studio
     * `parent`: the parent channel/network
     * `custom` : custom fields:
-        * `Traxxx Slug` : the matched id (for use by plugins)
+        * `Traxxx Slug` : the slug identifier (for use by plugins)
         * `Traxxx Type` : the type of channel/network (for use by plugins)
         * `Homepage` : the Homepage of the studio
 

--- a/plugins/traxxx/docs.md
+++ b/plugins/traxxx/docs.md
@@ -11,7 +11,7 @@ This plugin retrieves data from Traxxx.
     * `aliases` : aliases of the studio
     * `parent`: the parent channel/network
     * `custom` : custom fields:
-        * `Traxxx Id` : the matched id (for use by plugins)
+        * `Traxxx Slug` : the matched id (for use by plugins)
         * `Traxxx Type` : the type of channel/network (for use by plugins)
         * `Homepage` : the Homepage of the studio
 

--- a/plugins/traxxx/studio.ts
+++ b/plugins/traxxx/studio.ts
@@ -215,9 +215,9 @@ export class ChannelExtractor {
     return { parent: parentName };
   }
 
-  getCustom(): Partial<{ "Traxxx Id": number; "Traxxx Type": string; Homepage: string }> {
+  getCustom(): Partial<{ "Traxxx Slug": string; "Traxxx Type": string; Homepage: string }> {
     return {
-      ["Traxxx Id"]: this.preferredEntity?.entity?.id,
+      ["Traxxx Slug"]: this.preferredEntity?.entity?.slug,
       ["Traxxx Type"]: this.preferredEntity?.entity?.type,
       Homepage: this.preferredEntity?.entity?.url,
     };

--- a/plugins/traxxx/studio.ts
+++ b/plugins/traxxx/studio.ts
@@ -129,19 +129,15 @@ export class ChannelExtractor {
       return {};
     }
 
-    const imageUrls = buildImageUrls(entity);
+    const { logo } = buildImageUrls(entity);
 
-    if (!imageUrls.thumbnail) {
+    if (!logo) {
       return {};
     }
 
     const thumbnail = this.ctx.args.dry
-      ? `_would_have_created_${imageUrls.thumbnail}`
-      : await this.ctx.$createImage(
-          imageUrls.thumbnail,
-          this._getName().name || this.ctx.studioName,
-          true
-        );
+      ? `_would_have_created_${logo}`
+      : await this.ctx.$createImage(logo, this._getName().name || this.ctx.studioName, true);
 
     return {
       thumbnail,

--- a/plugins/traxxx/test/fixtures/studio.fixtures.js
+++ b/plugins/traxxx/test/fixtures/studio.fixtures.js
@@ -486,7 +486,7 @@ const EvilAngelChannelUniqueNames = {
   thumbnail: DUMMY_IMAGE_ID,
   parent: "Evil Angel (Network)",
   custom: {
-    "Traxxx Id": 291,
+    "Traxxx Slug": "evilangel",
     "Traxxx Type": "channel",
     Homepage: "https://www.evilangel.com",
   },
@@ -556,7 +556,7 @@ const Gamma = {
   thumbnail: DUMMY_IMAGE_ID,
   aliases: ["gammaentertainment"],
   custom: {
-    "Traxxx Id": 1,
+    "Traxxx Slug": "gamma",
     "Traxxx Type": "network",
     Homepage: "https://www.gammaentertainment.com",
   },
@@ -599,7 +599,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -619,7 +619,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -652,7 +652,7 @@ export const genericResultFixtures = [
       name: "Evil Angel",
       thumbnail: DUMMY_IMAGE_ID,
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -674,7 +674,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -696,7 +696,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -717,7 +717,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -738,7 +738,7 @@ export const genericResultFixtures = [
       name: "Evil Angel",
       thumbnail: DUMMY_IMAGE_ID,
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -759,7 +759,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -783,7 +783,7 @@ export const genericResultFixtures = [
       name: "Evil Angel (Channel)",
       thumbnail: DUMMY_IMAGE_ID,
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -807,7 +807,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -830,7 +830,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -854,7 +854,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -878,7 +878,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Gamma Entertainment",
       custom: {
-        "Traxxx Id": 28,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "network",
         Homepage: "https://www.evilangel.com",
       },
@@ -949,7 +949,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       aliases: ["dummy alias", "gammaentertainment"],
       custom: {
-        "Traxxx Id": 1,
+        "Traxxx Slug": "gamma",
         "Traxxx Type": "network",
         Homepage: "https://www.gammaentertainment.com",
       },
@@ -972,7 +972,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       aliases: ["gammaentertainment"],
       custom: {
-        "Traxxx Id": 1,
+        "Traxxx Slug": "gamma",
         "Traxxx Type": "network",
         Homepage: "https://www.gammaentertainment.com",
       },
@@ -995,7 +995,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       aliases: ["gammaentertainment"],
       custom: {
-        "Traxxx Id": 1,
+        "Traxxx Slug": "gamma",
         "Traxxx Type": "network",
         Homepage: "https://www.gammaentertainment.com",
       },
@@ -1016,7 +1016,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1035,7 +1035,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1055,7 +1055,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1073,7 +1073,7 @@ export const genericResultFixtures = [
     result: {
       name: "Evil Angel",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1089,7 +1089,7 @@ export const genericResultFixtures = [
     errored: false,
     result: {
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1113,7 +1113,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1139,7 +1139,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1165,7 +1165,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },
@@ -1187,7 +1187,7 @@ export const genericResultFixtures = [
       thumbnail: DUMMY_IMAGE_ID,
       parent: "Evil Angel (Network)",
       custom: {
-        "Traxxx Id": 291,
+        "Traxxx Slug": "evilangel",
         "Traxxx Type": "channel",
         Homepage: "https://www.evilangel.com",
       },


### PR DESCRIPTION
- traxxx: return slugs instead of ids. They are constant compared to ids that will change if the database is rebuilt
- freeones: update avatar selector
- Closes #64 #65 